### PR TITLE
go version update & ca-certificates update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 # Build stage
-FROM golang:1.12.7-alpine3.10 AS build-env
+FROM golang:1.16.6-alpine3.14 AS build-env
 
 RUN addgroup -S -g 20002 appgroup \
     && adduser -D -u 20001 -s /sbin/nologin -g 'Application User' appuser -G appgroup appgroup
+
+RUN apk --update --no-cache add ca-certificates
 
 COPY . /go/src/github.com/ernst01/go-start-http-api/
 WORKDIR /go/src/github.com/ernst01/go-start-http-api/
@@ -16,6 +18,8 @@ RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test ./... -v -cover
 
 # Final stage
 FROM scratch
+
+COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 COPY --from=build-env /etc/passwd /etc/passwd
 USER 20001

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ernst01/go-start-http-api
 
-go 1.12
+go 1.16
 
 require (
 	github.com/ernst01/common v0.0.0-20190728223912-6d900e01e636

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,9 @@
 # github.com/ernst01/common v0.0.0-20190728223912-6d900e01e636
+## explicit
 github.com/ernst01/common/pkg/response
 # github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+## explicit
 github.com/golang/glog
 # github.com/gorilla/mux v1.7.3
+## explicit
 github.com/gorilla/mux


### PR DESCRIPTION
Related to:
- https://github.com/tebo-ernstberger/go-start-http-api/issues/1

Which includes:
- Upgrade to go 1.16.6
- ca-certificates update